### PR TITLE
Updates to query pagination logic to utilize yield statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ N/A
 
 Install with:
 
-    pip install peppi
+    pip install pds.peppi
 
 
 ## Code of Conduct

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,7 @@ omit = */_version.py,*/__init__.py
 #
 # See https://docs.pytest.org/ for more information.
 [tool:pytest]
-addopts = -n auto --cov=pds
+addopts =
 
 
 # Installation Options


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This PR updates the pagination logic in the `client.Products` class to utilize `yield` statements, as suggested by @nutjob4life. This branch also adds checks to ensure that a user cannot modify a query clause mid-pagination, as this could break the logic when fetching new pages.

Lastly, this branch also fixes an issue in README.md where the `pip install` command was incorrect.

## ⚙️ Test Data and/or Report
Unit test suite has been updated to account for new pagination logic, as well as add a test for the new check on modification of a query clause while iterating over results.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #51 

