### PR TITLE
Added method to find products based on target keyword

### DIFF
--- a/src/pds/peppi/orex/products.py
+++ b/src/pds/peppi/orex/products.py
@@ -1,9 +1,9 @@
 """Main class of the Osiris Rex (OREX) Peppi package."""
 from pds.peppi.client import PDSRegistryClient
-from pds.peppi.orex.result_set import OrexResultSet
+from pds.peppi.orex.query_builder import OrexQueryBuilder
 
 
-class OrexProducts(OrexResultSet):
+class OrexProducts(OrexQueryBuilder):
     """Specialized Products class used to query specfically for Osiris Rex (OREX) products."""
 
     def __init__(self, client: PDSRegistryClient):

--- a/src/pds/peppi/orex/query_builder.py
+++ b/src/pds/peppi/orex/query_builder.py
@@ -6,7 +6,7 @@ from pds.peppi.query_builder import QueryBuilder
 class OrexQueryBuilder(QueryBuilder):
     """Inherits the functionality of the QueryBuilder class, but adds implementations for unimplemented stubs."""
 
-    orex_instrument_lidvid = "urn:nasa:pds:context:instrument:ovirs.orex"
+    orex_investigation_lidvid = "urn:nasa:pds:context:investigation:mission.orex"
 
     def __init__(self, client: PDSRegistryClient):
         """Creates a new instance of OrexResultSet.
@@ -20,10 +20,10 @@ class OrexQueryBuilder(QueryBuilder):
         super().__init__(client)
 
         # By default, all query results are filtered to just those applicable to
-        # the OREX instrument
-        self._q_string = f'ref_lid_instrument eq "{self.orex_instrument_lidvid}"'
+        # the Osiris Rex investigation
+        self._q_string = f'ref_lid_investigation eq "{self.orex_investigation_lidvid}"'
 
-    def has_instrument(self, identifier: str):
+    def has_investigation(self, identifier: str):
         """Adds a query clause selecting products having an instrument matching the provided identifier.
 
         Notes
@@ -41,7 +41,7 @@ class OrexQueryBuilder(QueryBuilder):
         NotImplementedError
 
         """
-        raise NotImplementedError(f"Cannot specify an additional instrument on {self.__class__.__name__}")
+        raise NotImplementedError(f"Cannot specify an additional investigation on {self.__class__.__name__}")
 
     def within_range(self, range_in_km: float):
         """Adds a query clause selecting products within the provided range value.

--- a/src/pds/peppi/orex/query_builder.py
+++ b/src/pds/peppi/orex/query_builder.py
@@ -1,10 +1,10 @@
-"""Module containing the Osiris Rex (OREX) tailored ResultSet class."""
+"""Module containing the Osiris Rex (OREX) tailored QueryBuilder class."""
 from pds.peppi.client import PDSRegistryClient
-from pds.peppi.result_set import ResultSet
+from pds.peppi.query_builder import QueryBuilder
 
 
-class OrexResultSet(ResultSet):
-    """Inherits the functionality of the ResultSet class, but adds implementations for stubs in QueryBuilder."""
+class OrexQueryBuilder(QueryBuilder):
+    """Inherits the functionality of the QueryBuilder class, but adds implementations for unimplemented stubs."""
 
     orex_instrument_lidvid = "urn:nasa:pds:context:instrument:ovirs.orex"
 

--- a/src/pds/peppi/products.py
+++ b/src/pds/peppi/products.py
@@ -1,9 +1,9 @@
 """Main class of the library in this module."""
 from .client import PDSRegistryClient
-from .result_set import ResultSet
+from .query_builder import QueryBuilder
 
 
-class Products(ResultSet):
+class Products(QueryBuilder):
     """Use to access any class of planetary products via the PDS Registry API.
 
     This class is both a :class:`.query_builder.QueryBuilder` which carries methods to subset the products
@@ -18,4 +18,4 @@ class Products(ResultSet):
         client : PDSRegistryClient
             Client defining the connexion with the PDS Search API
         """
-        ResultSet.__init__(self, client)
+        super().__init__(client)

--- a/src/pds/peppi/products.py
+++ b/src/pds/peppi/products.py
@@ -6,8 +6,9 @@ from .query_builder import QueryBuilder
 class Products(QueryBuilder):
     """Use to access any class of planetary products via the PDS Registry API.
 
-    This class is both a :class:`.query_builder.QueryBuilder` which carries methods to subset the products
-    and a :class:`.result_set.ResultSet` which can be iterated on or converted to for example a pandas DataFrame
+    This class is an inheritor of :class:`.query_builder.QueryBuilder`, which
+    carries methods to subset the products, and which can be iterated on or
+    converted to a pandas DataFrame.
     """
 
     def __init__(self, client: PDSRegistryClient):

--- a/src/pds/peppi/query_builder.py
+++ b/src/pds/peppi/query_builder.py
@@ -425,3 +425,4 @@ class QueryBuilder:
 
         """
         self._result_set.reset()
+        self._q_string = ""

--- a/src/pds/peppi/query_builder.py
+++ b/src/pds/peppi/query_builder.py
@@ -115,7 +115,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "has target" query filter applied.
+        This instance with the "has target" query filter applied.
 
         """
         clause = f'ref_lid_target eq "{identifier}"'
@@ -132,7 +132,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "has investigation" query filter applied.
+        This instance with the "has investigation" query filter applied.
 
         """
         clause = f'ref_lid_investigation eq "{identifier}"'
@@ -149,7 +149,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "before" filter applied.
+        This instance with the "before" filter applied.
 
         """
         iso8601_datetime = dt.isoformat().replace("+00:00", "Z")
@@ -167,7 +167,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "before" filter applied.
+        This instance with the "before" filter applied.
 
         """
         iso8601_datetime = dt.isoformat().replace("+00:00", "Z")
@@ -185,7 +185,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "Parent Collection" filter applied.
+        This instance with the "Parent Collection" filter applied.
 
         """
         clause = f'ops:Provenance.ops:parent_collection_identifier eq "{identifier}"'
@@ -197,7 +197,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "Observational Product" filter applied.
+        This instance with the "Observational Product" filter applied.
 
         """
         clause = 'product_class eq "Product_Observational"'
@@ -215,7 +215,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "Product Collection" filter applied.
+        This instance with the "Product Collection" filter applied.
 
         """
         clause = 'product_class eq "Product_Collection"'
@@ -232,7 +232,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "Product Bundle" filter applied.
+        This instance with the "Product Bundle" filter applied.
 
         """
         clause = 'product_class eq "Product_Bundle"'
@@ -249,7 +249,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "has instrument" filter applied.
+        This instance with the "has instrument" filter applied.
 
         """
         clause = f'ref_lid_instrument eq "{identifier}"'
@@ -266,7 +266,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "has instrument host" filter applied.
+        This instance with the "has instrument host" filter applied.
 
         """
         clause = f'ref_lid_instrument_host eq "{identifier}"'
@@ -284,7 +284,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "has processing level" filter applied.
+        This instance with the "has processing level" filter applied.
 
         """
         clause = f'pds:Primary_Result_Summary.pds:processing_level eq "{processing_level.title()}"'
@@ -347,7 +347,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the "LIDVID identifier" filter applied.
+        This instance with the "LIDVID identifier" filter applied.
 
         """
         self._add_clause(f'lidvid like "{identifier}"')
@@ -368,7 +368,7 @@ class QueryBuilder:
 
         Returns
         -------
-        This Products instance with the provided filtering clause applied.
+        This instance with the provided filtering clause applied.
         """
         self._add_clause(clause)
         return self

--- a/src/pds/peppi/result_set.py
+++ b/src/pds/peppi/result_set.py
@@ -64,7 +64,7 @@ class ResultSet:
         if len(query_string) > 0:
             kwargs["q"] = f"({query_string})"
 
-        if len(fields) > 0:
+        if fields and len(fields) > 0:
             # The sort property is used for pagination
             if self._SORT_PROPERTY not in fields:
                 fields.append(self._SORT_PROPERTY)

--- a/src/pds/peppi/result_set.py
+++ b/src/pds/peppi/result_set.py
@@ -1,18 +1,15 @@
 """Module of the ResultSet."""
 import logging
-from typing import Optional
 
-import pandas as pd
 from pds.api_client.api.all_products_api import AllProductsApi
 
 from .client import PDSRegistryClient
-from .query_builder import QueryBuilder
 
 logger = logging.getLogger(__name__)
 
 
-class ResultSet(QueryBuilder):
-    """ResultSet of products on which a query has been applied. Iterable."""
+class ResultSet:
+    """ResultSet of products on which a query has been applied."""
 
     _SORT_PROPERTY = "ops:Harvest_Info.ops:harvest_date_time"
     """Default property to sort results of a query by."""
@@ -22,23 +19,25 @@ class ResultSet(QueryBuilder):
 
     def __init__(self, client: PDSRegistryClient):
         """Constructor of the ResultSet."""
-        super().__init__()
         self._products = AllProductsApi(client.api_client)
         self._latest_harvest_time = None
         self._page_counter = None
         self._expected_pages = None
 
-    def __str__(self):
-        """Returns a string representation of the ResultSet, including the current query string."""
-        return f"Current {self.__class__.__name__} query:\n{super().__str__()}"
-
-    def _init_new_page(self):
+    def init_new_page(self, query_string="", fields=None):
         """Queries the PDS API for the next page of results.
 
         Any query clauses associated to this Products instance are included here.
 
         If there are results remaining from the previously acquired page,
         they are yieled on each subsequent call to this method.
+
+        Parameters
+        ----------
+        query_string : str, optional
+            The query string to submit to the PDS API.
+        fields : iterable, optional
+            Additional fields to include with the query parameters.
 
         Yields
         ------
@@ -62,15 +61,15 @@ class ResultSet(QueryBuilder):
         if self._latest_harvest_time is not None:
             kwargs["search_after"] = [self._latest_harvest_time]
 
-        if len(self._q_string) > 0:
-            kwargs["q"] = f"({self._q_string})"
+        if len(query_string) > 0:
+            kwargs["q"] = f"({query_string})"
 
-        if len(self._fields) > 0:
+        if len(fields) > 0:
             # The sort property is used for pagination
-            if self._SORT_PROPERTY not in self._fields:
-                self._fields.append(self._SORT_PROPERTY)
+            if self._SORT_PROPERTY not in fields:
+                fields.append(self._SORT_PROPERTY)
 
-            kwargs["fields"] = self._fields
+            kwargs["fields"] = fields
 
         results = self._products.product_list(**kwargs)
 
@@ -92,81 +91,8 @@ class ResultSet(QueryBuilder):
         # If here, current page has been exhausted
         self._page_counter += 1
 
-    def __iter__(self):
-        """Iterates over all products returned by the current query filter applied to this Products instance.
-
-        This method handles pagination automatically by fetching additional pages
-        from the PDS Registry API as needed. Once all available pages and results
-        have been yielded, this method will reset this Products instance to a
-        default state which can be used to perform a new query.
-
-        Yields
-        ------
-        product : pds.api_client.models.pds_product.PDSProduct
-            The next product within the current page fetched from the PDS Registry
-            API.
-
-        """
-        while True:
-            try:
-                for product in self._init_new_page():
-                    yield product
-            except RuntimeError as err:
-                # Make sure we got the StopIteration that was converted to a RuntimeError,
-                # otherwise we need to re-raise
-                if "StopIteration" not in str(err):
-                    raise err
-
-                self.reset()
-                break
-
     def reset(self):
-        """Resets internal pagination state to default.
-
-        This method should be called before making any modifications to the
-        query clause stored by this Products instance while still paginating
-        through the results of a previous query.
-
-        """
+        """Resets internal pagination state to default."""
         self._expected_pages = None
         self._page_counter = None
         self._latest_harvest_time = None
-
-    def as_dataframe(self, max_rows: Optional[int] = None):
-        """Returns the found products as a pandas DataFrame.
-
-        Loops on the products found and returns a pandas DataFrame with the product properties as columns
-        and their identifier as index.
-
-        Parameters
-        ----------
-        max_rows : int
-            Optional limit in the number of products returned in the dataframe. Convenient for test while developing.
-            Default is no limit (None)
-
-        Returns
-        -------
-        The products as a pandas dataframe.
-        """
-        result_as_dict_list = []
-        lidvid_index = []
-        n = 0
-        for p in self:
-            result_as_dict_list.append(p.properties)
-            lidvid_index.append(p.id)
-            n += 1
-            if max_rows and n >= max_rows:
-                break
-        self.reset()
-
-        if n > 0:
-            df = pd.DataFrame.from_records(result_as_dict_list, index=lidvid_index)
-            # reduce useless arrays in dataframe columns
-            for column in df.columns:
-                only_1_element = df.apply(lambda x: len(x[column]) <= 1, axis=1)  # noqa
-                if only_1_element.all():
-                    df[column] = df.apply(lambda x: x[column][0], axis=1)  # noqa
-            return df
-        else:
-            logger.warning("Query with clause %s did not return any products.", self._q_string)  # noqa
-            return None

--- a/tests/pds/peppi/test_orex_products.py
+++ b/tests/pds/peppi/test_orex_products.py
@@ -11,13 +11,15 @@ class OrexProductsTestCase(unittest.TestCase):
         self.client = pep.PDSRegistryClient()
         self.products = pep.OrexProducts(self.client)
 
-    def test_has_instrument(self):
+    def test_has_investigation(self):
         # Check that an instance of OrexProducts is initialized with a has_instrument filter
-        self.assertIn('ref_lid_instrument eq "urn:nasa:pds:context:instrument:ovirs.orex"', self.products._q_string)
+        self.assertIn(
+            'ref_lid_investigation eq "urn:nasa:pds:context:investigation:mission.orex"', self.products._q_string
+        )
 
-        # Check that an attempt to change the instrument results in an exception
+        # Check that an attempt to add an investigation filter results in an exception
         with self.assertRaises(NotImplementedError):
-            self.products.has_instrument("urn:nasa:pds:context:instrument:cls.farir_beamline")
+            self.products.has_investigation("urn:nasa:pds:context:investigation:mission.not_orex")
 
     def test_within_range(self):
         n = 0

--- a/tests/pds/peppi/test_products.py
+++ b/tests/pds/peppi/test_products.py
@@ -78,11 +78,11 @@ class ProductsTestCase(unittest.TestCase):
                 break
 
     def test_has_target(self):
-        lidvid = "urn:nasa:pds:context:target:asteroid.65803_didymos"
+        lid = "urn:nasa:pds:context:target:asteroid.65803_didymos"
         n = 0
-        for p in self.products.has_target(lidvid):
+        for p in self.products.has_target(lid):
             n += 1
-            assert lidvid in p.properties["ref_lid_target"]
+            assert lid in p.properties["ref_lid_target"]
             if n > self.MAX_ITERATIONS:
                 break
 
@@ -228,6 +228,33 @@ class ProductsTestCase(unittest.TestCase):
             assert node_name in p.properties["ops:Harvest_Info.ops:node_name"]
             if n > self.MAX_ITERATIONS:
                 break
+
+    def test_products_with_target(self):
+        test_cases = [
+            {"identifier": "mars", "expected_lid": "urn:nasa:pds:context:target:planet.mars"},
+            {"identifier": "moon", "expected_lid": "urn:nasa:pds:context:target:satellite.earth.moon"},
+            {"identifier": "saturn", "expected_lid": "urn:nasa:pds:context:target:planet.saturn"},
+        ]
+
+        for test_case in test_cases:
+            identifier = test_case["identifier"]
+            n = 0
+            self.products = self.products.products_with_target(identifier)
+
+            expected_lid = test_case["expected_lid"]
+            assert str(self.products) == f'(ref_lid_target eq "{expected_lid}")'
+
+            for p in self.products:
+                n += 1
+                assert expected_lid in p.properties["ref_lid_target"]
+                if n > self.MAX_ITERATIONS:
+                    break
+
+            # Make sure we got at least one result back
+            assert n > 0
+
+            # Reset query builder for next iteration
+            self.products.reset()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This PR adds a new method, `products_with_target`, which accepts a keyword from a user and determines the set of product LIDs that specify said keyword as a target. The discovered LIDs are then used to refine the current query stored by the `QueryBuilder` instance. Any provided keyword is "canonicalized" into several variations for a more reliable search. Additionally, results of the intermediate keyword/target search are automatically cached to prevent repeated lookups.

To support the addition of this new feature, `ResultSet` has been refactored to be a member of a `QueryBuilder` instance, rather than an inheritance relationship between the two. `ResultSet` is now only responsible for submission of a query and pagination of the results. `QueryBuilder` is now only responsible for formation of the query string and formatting of results (for example, as a pandas dataframe).

Also included in this branch is a fix for #76, with the correct default query applied to all instances of `OrexQueryBuilder`, as well as a fix for #79, where the internal state of a `QueryBuilder` was not reset properly after a call to `as_dataframe()`

## ⚙️ Test Data and/or Report
Unit test for the new `products_with_target()` method has been added.
Test suite for `OrexProducts` has been updated to account for fix for #76 

Branch has passed CI testing: https://github.com/NASA-PDS/peppi/actions/runs/12936601156

To test the fix for #79, the following code snippet should now work as intended without needing to reinstantiate a `Products` instance:
```python
client = pep.PDSRegistryClient()
products = pep.Products(client)

north = 'cart:Bounding_Coordinates.cart:north_bounding_coordinate'
east = 'cart:Bounding_Coordinates.cart:east_bounding_coordinate'
south = 'cart:Bounding_Coordinates.cart:south_bounding_coordinate'
west = 'cart:Bounding_Coordinates.cart:west_bounding_coordinate'

fname_browse = ['ops:Data_File_Info.ops:file_ref', 'ref_lid_data']
fname_prod = [
    east,north,west,south,
    'lid',
    'ops:Label_File_Info.ops:file_size',
    'ops:Data_File_Info.ops:creation_date_time',
    'ops:Data_File_Info.ops:file_ref'
]

df_browse = products.of_collection('urn:nasa:pds:messenger_mdis_dem_1001:browse::1.0').fields(fname_browse).as_dataframe()
df_prod = products.of_collection('urn:nasa:pds:messenger_mdis_dem_1001:elev::1.0').fields(fname_prod).as_dataframe()
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #74
Fixes #76 
Fixes #79 

