### PR TITLE
iteration on has_target from keyword

### DIFF
--- a/tests/pds/peppi/quickstart.py
+++ b/tests/pds/peppi/quickstart.py
@@ -12,7 +12,7 @@ date1 = datetime.fromisoformat("2012-01-23")
 # in the `PDS keyword search <https://pds.nasa.gov/datasearch/keyword-search/search.jsp>`_
 mercury_id = "urn:nasa:pds:context:target:planet.mercury"
 # filter here:
-products = pep.Products(client).has_target(mercury_id).before(date1).observationals()
+products = pep.Products(client).has_target("Mercury").before(date1).observationals()
 
 # Iterate on the results:
 for i, p in enumerate(products):

--- a/tests/pds/peppi/test_products.py
+++ b/tests/pds/peppi/test_products.py
@@ -1,9 +1,12 @@
+import logging
 import unittest
 from datetime import datetime
 from typing import get_args
 
 import pds.peppi as pep  # type: ignore
 from pds.api_client import PdsProduct
+
+logger = logging.getLogger(__name__)
 
 
 class ProductsTestCase(unittest.TestCase):
@@ -231,18 +234,18 @@ class ProductsTestCase(unittest.TestCase):
 
     def test_products_with_target(self):
         test_cases = [
-            {"identifier": "mars", "expected_lid": "urn:nasa:pds:context:target:planet.mars"},
-            {"identifier": "moon", "expected_lid": "urn:nasa:pds:context:target:satellite.earth.moon"},
-            {"identifier": "saturn", "expected_lid": "urn:nasa:pds:context:target:planet.saturn"},
+            {"title": "mars", "expected_lid": "urn:nasa:pds:context:target:planet.mars"},
+            {"title": "moon", "expected_lid": "urn:nasa:pds:context:target:satellite.earth.moon"},
+            {"title": "saturn", "expected_lid": "urn:nasa:pds:context:target:planet.saturn"},
         ]
 
         for test_case in test_cases:
-            identifier = test_case["identifier"]
+            title = test_case["title"]
             n = 0
-            self.products = self.products.products_with_target(identifier)
+            self.products = self.products.has_target(title)
 
             expected_lid = test_case["expected_lid"]
-            assert str(self.products) == f'(ref_lid_target eq "{expected_lid}")'
+            assert str(self.products) == f'((ref_lid_target eq "{expected_lid}"))'
 
             for p in self.products:
                 n += 1
@@ -255,6 +258,14 @@ class ProductsTestCase(unittest.TestCase):
 
             # Reset query builder for next iteration
             self.products.reset()
+
+    def test_product_has_target_not_found_raise_warning(self):
+        with self.assertLogs(level="INFO") as log:
+            self.products = self.products.has_target("not_existing_target_title")
+            for _ in self.products:
+                break
+
+            self.assertTrue(any(item.startswith("WARNING") for item in log.output))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
- merge the has_target with lid argument with the has_target with the keyword argument
- use description/title instead or target/name to retrieve the target
- add alt_title to retrieve target
- create a contexts() method to help to retrieve the targets 
- add warning log when no target was found
- other minor updates

## ⚙️ Test Data and/or Report
Test available in unittest.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

improves https://github.com/NASA-PDS/peppi/issues/74

