### PR TITLE
Add a targets Enumeration-like, Searchable object

### DIFF
--- a/src/pds/peppi/__init__.py
+++ b/src/pds/peppi/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """PDS peppi."""
 from .client import PDSRegistryClient  # noqa
+from .context import Context  # noqa
 from .orex import OrexProducts  # noqa
 from .products import Products  # noqa

--- a/src/pds/peppi/context.py
+++ b/src/pds/peppi/context.py
@@ -1,6 +1,4 @@
 """Module for Context product aggregation (targets, investigations, ...)."""
-from cachetools import cached
-
 from .products import Products
 from .query_builder import PDSRegistryClient
 from .targets import Targets
@@ -9,15 +7,15 @@ from .targets import Targets
 class Context:
     """Aggregation of all the context products  (targets, investigations, instruments...) known in the PDS."""
 
-    def __init__(self, client: PDSRegistryClient):
+    def __init__(self, client: PDSRegistryClient = None):
         """Contructor."""
-        client = PDSRegistryClient()
+        if client is None:
+            client = PDSRegistryClient()
         self.__context_products__ = Products(client).contexts()
 
     @property
-    @cached
     def TARGETS(self):  # noqa
-        """Targets dynimcally populated from the RESTFul API."""
+        """Targets dynamically populated from the RESTFul API."""
         targets = Targets()
         for api_target in self.__context_products__:
             if "pds:Target.pds:name" in api_target.properties:

--- a/src/pds/peppi/context.py
+++ b/src/pds/peppi/context.py
@@ -8,7 +8,7 @@ class Context:
     """Aggregation of all the context products  (targets, investigations, instruments...) known in the PDS."""
 
     def __init__(self, client: PDSRegistryClient = None):
-        """Contructor."""
+        """Constructor."""
         if client is None:
             client = PDSRegistryClient()
         self.__context_products__ = Products(client).contexts()

--- a/src/pds/peppi/context.py
+++ b/src/pds/peppi/context.py
@@ -1,0 +1,25 @@
+"""Module for Context product aggregation (targets, investigations, ...)."""
+from cachetools import cached
+
+from .products import Products
+from .query_builder import PDSRegistryClient
+from .targets import Targets
+
+
+class Context:
+    """Aggregation of all the context products  (targets, investigations, instruments...) known in the PDS."""
+
+    def __init__(self, client: PDSRegistryClient):
+        """Contructor."""
+        client = PDSRegistryClient()
+        self.__context_products__ = Products(client).contexts()
+
+    @property
+    @cached
+    def TARGETS(self):  # noqa
+        """Targets dynimcally populated from the RESTFul API."""
+        targets = Targets()
+        for api_target in self.__context_products__:
+            if "pds:Target.pds:name" in api_target.properties:
+                targets.add_target(api_target)
+        return targets

--- a/src/pds/peppi/targets.py
+++ b/src/pds/peppi/targets.py
@@ -1,0 +1,88 @@
+"""Module handling target related objects."""
+import difflib
+from dataclasses import dataclass
+
+
+@dataclass
+class Target:
+    """Simple object describing a target."""
+
+    lid: str
+    code: str
+    code: str
+    name: str
+    type: str
+    description: str
+
+    @property
+    def tokens(self):
+        """Not used.
+
+        Was proposed to search against all text available in the object
+        but it is not efficient as it created false match when the description
+        contains something like "unlike jupiter", it matches with jupiter
+        unless we had a semantically aware search, which we don't know.
+        :return:
+        """
+        tokens = set()
+        for value in vars(self).values():
+            for token in str(value).lower().split(" "):
+                tokens.add(token)
+        return tokens
+
+
+class Targets:
+    """Searchable enumeration of the planetary bodies, called targets, described in the Planetary Data System.
+
+    When the code of the target is know it can be accessed with the code:
+
+        client = pep.PDSRegistryClient()
+        context = pep.Context(client)
+        context.TARGETS.JUPITER
+
+    When the code is not known yet, search with line:
+
+        jupiter = context.TARGETS.search("jupiter")
+
+    Or supported with a typo:
+
+        jupiter = context.TARGETS.search("jupyter")
+
+    """
+
+    def __init__(self):
+        """Constructor. Creates an empty aggegation of targets."""
+        self.__targets__: list[Target] = []
+        self.__keywords_target_map__ = {}
+
+    @staticmethod
+    def target_dict_to_obj(target: dict):
+        """Transform the RESTFul API product object into the Target object."""
+        code = target.properties["pds:Target.pds:name"][0].upper().replace(" ", "_")
+        return Target(
+            lid=target.properties["lid"][0],
+            code=code,
+            name=target.properties["pds:Target.pds:name"][0],
+            type=target.properties["pds:Target.pds:type"][0],
+            description=target.properties["pds:Target.pds:description"][0],
+        )
+
+    def add_target(self, api_target: dict):
+        """For internal use, adds target from the API response's objects into the enumeration."""
+        target_obj = self.target_dict_to_obj(api_target)
+        self.__targets__.append(target_obj)
+        setattr(self, target_obj.code, target_obj)
+
+    def search(self, term: str, threshold=0.8):
+        """Search entries in the enumeration. Tolerates typos.
+
+        :param term: name to search for.
+        :param threshold: from 0 to 1, lower gives more results, higher only the exact match.
+        :return: a list of mathing targets sorted from the best match to the not-as-best matches.
+        """
+        matching_targets = []
+        for target in self.__targets__:
+            search_score = difflib.SequenceMatcher(None, term.lower(), target.name.lower()).ratio()
+            if search_score >= threshold:
+                matching_targets.append((target, search_score))
+        return sorted(matching_targets, key=lambda x: x[1], reverse=True)

--- a/src/pds/peppi/targets.py
+++ b/src/pds/peppi/targets.py
@@ -36,8 +36,7 @@ class Targets:
 
     When the code of the target is know it can be accessed with the code:
 
-        client = pep.PDSRegistryClient()
-        context = pep.Context(client)
+        context = pep.Context()
         context.TARGETS.JUPITER
 
     When the code is not known yet, search with line:

--- a/src/pds/peppi/targets.py
+++ b/src/pds/peppi/targets.py
@@ -14,22 +14,6 @@ class Target:
     type: str
     description: str
 
-    @property
-    def tokens(self):
-        """Not used.
-
-        Was proposed to search against all text available in the object
-        but it is not efficient as it created false match when the description
-        contains something like "unlike jupiter", it matches with jupiter
-        unless we had a semantically aware search, which we don't know.
-        :return:
-        """
-        tokens = set()
-        for value in vars(self).values():
-            for token in str(value).lower().split(" "):
-                tokens.add(token)
-        return tokens
-
 
 class Targets:
     """Searchable enumeration of the planetary bodies, called targets, described in the Planetary Data System.

--- a/tests/pds/peppi/quickstart.py
+++ b/tests/pds/peppi/quickstart.py
@@ -17,3 +17,6 @@ for i, p in enumerate(products):
     # there a lot of there data, break after a couple of hundreds
     if i > 200:
         break
+
+
+pep.Context().TARGETS

--- a/tests/pds/peppi/test_products.py
+++ b/tests/pds/peppi/test_products.py
@@ -270,15 +270,13 @@ class ProductsTestCase(unittest.TestCase):
                 break
 
     def test_has_target_mercury_observationals(self):
-        n = 0
-        for p in self.products.has_target("mercury").observationals():
-            n += 1
+        for i, p in enumerate(self.products.has_target("mercury").observationals()):
             assert p.properties["ref_lid_target"][0] == "urn:nasa:pds:context:target:planet.mercury"
             assert p.properties["product_class"][0] == "Product_Observational"
-            if n > self.MAX_ITERATIONS:
+            if i > self.MAX_ITERATIONS:
                 break
 
-        assert n == self.MAX_ITERATIONS + 1
+        assert i == self.MAX_ITERATIONS + 1
 
 
 if __name__ == "__main__":

--- a/tests/pds/peppi/test_targets.py
+++ b/tests/pds/peppi/test_targets.py
@@ -1,0 +1,27 @@
+import unittest
+
+import pds.peppi as pep
+
+
+class TargetsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        client = pep.PDSRegistryClient()
+        context = pep.Context(client)
+        self.targets = context.TARGETS
+
+    def test_targets(self):
+        assert hasattr(self.targets, "SETEBOS") == True
+        assert self.targets.SETEBOS.name == "Setebos"
+        assert self.targets.SETEBOS.lid == "urn:nasa:pds:context:target:satellite.uranus.setebos"
+
+    def test_search(self):
+        result = self.targets.search("jupiter")
+        assert result[0][0].lid == "urn:nasa:pds:context:target:planet.jupiter"
+
+        # with typo
+        result = self.targets.search("jupyter")
+        assert result[0][0].lid == "urn:nasa:pds:context:target:planet.jupiter"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pds/peppi/test_targets.py
+++ b/tests/pds/peppi/test_targets.py
@@ -5,8 +5,7 @@ import pds.peppi as pep
 
 class TargetsTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        client = pep.PDSRegistryClient()
-        context = pep.Context(client)
+        context = pep.Context()
         self.targets = context.TARGETS
 
     def test_targets(self):


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Add a new object `Targets` which is dynamically populated with all the PDS known targets and searchable. 

## ⚙️ Test Data and/or Report
Test with unit tests:

    pytest

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Fixes #99 
